### PR TITLE
Fix issue 1710

### DIFF
--- a/mezzanine/generic/views.py
+++ b/mezzanine/generic/views.py
@@ -65,9 +65,10 @@ def initial_validation(request, prefix):
     redirect_url = ""
     if getattr(settings, login_required_setting_name, False):
         if not request.user.is_authenticated():
-            request.session[posted_session_key] = request.POST
-            error(request, _("You must be logged in. Please log in or "
-                             "sign up to complete this action."))
+            if request.method == "POST":
+                request.session[posted_session_key] = request.POST
+                error(request, _("You must be logged in. Please log in or "
+                                 "sign up to complete this action."))
             redirect_url = "%s?next=%s" % (settings.LOGIN_URL, reverse(prefix))
         elif posted_session_key in request.session:
             post_data = request.session.pop(posted_session_key)


### PR DESCRIPTION
During user validation, only save POST data in session if it is a POST
request, otherwise saved comment may be overwritten by GET request that
results from redirect if user verification is required.

https://github.com/stephenmcd/mezzanine/issues/1710